### PR TITLE
Non id tabs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,8 @@ Scrollimate focuses on features and functions related to scrolling, animations (
      - [SA Tabs](#saTabs)
          - [Markup](#saTabsMarkup)
          - [Setup](#saTabsSetup)
-         - [Exclusion](#saTabsExclusion)
+         - [Advanced Setup](#saTabsAdvSetup)
+         - [Exclude Links](#saTabsExclusion)
      - [SA Scroll Class](#saScrollclass)
          - [Baisc Setup](#saScrollclassBasic)
      - [SA Accordion](#saAccordion)
@@ -213,9 +214,24 @@ Note: (The class for the active tab on the navigation is `.tabscroll_activeNavi`
 
 1. Follow the Instructions for Scrollimate Installation
 2. Call the Method once on the page:
-  `<script> scrollimate.saTabs; </script>` (You may also use the init function by supplying 'saScroll' as an additional argument)
+  `<script> scrollimate.saTabs; </script>` (You may also use the init function by supplying 'saTabs' as an additional argument)
 
-### <a name="saTabsExclusion"></a>EXCLUSION
+### <a name="saTabsAdvSetup"></a>ADVANCED SETUP:
+
+#### Transitions
+
+You can control the type of transition between tabs with the `data-tabscrollnavcontainer` attribute. You can set it to:
+- `fade`
+- `slide`
+- or leave blank for no transition at all
+
+#### Non-Index Version
+
+You may not want your tabs to be indexed / indexable. Tabscroll keeps track of your tabs via the URL, by adding a fragment (“hash”) to the end of the URL. **But what if you have an application on your page that already does that?**
+
+Now Tabscroll can accomodate, by simply calling the `saTabs.nonID();` method some time *after* you included tabscroll.js. This will not index your tabs, not write to the URL, but still keep the same markup and functionality for your tabs.
+
+### <a name="saTabsExclusion"></a>EXCLUDE LINKS
 
 You want to have a link within your navigation that does something else. An external link, a popup link, etc. This is possible by simply adding the `data-saexclude` attribute to the anchor element.
 

--- a/readme.md
+++ b/readme.md
@@ -227,9 +227,9 @@ You can control the type of transition between tabs with the `data-tabscrollnavc
 
 #### Non-Index Version
 
-You may not want your tabs to be indexed / indexable. Tabscroll keeps track of your tabs via the URL, by adding a fragment (“hash”) to the end of the URL. **But what if you have an application on your page that already does that?**
+You may not want your tabs to be indexed / indexable. SA Tabs keeps track of your tabs via the URL, by adding a fragment (“hash”) to the end of the URL. **But what if you have an application on your page that already does that?**
 
-Now Tabscroll can accomodate, by simply calling the `saTabs.nonID();` method some time *after* you included tabscroll.js. This will not index your tabs, not write to the URL, but still keep the same markup and functionality for your tabs.
+Now SA Tabs can accomodate, by simply calling the `nonIDTabs();` method some time *after* the initial setup. (You can it as an additional argument to the `init` method, *after* the `saTabs` Method) This will not index your tabs, not write to the URL, but still keep the same markup and functionality for your tabs.
 
 ### <a name="saTabsExclusion"></a>EXCLUDE LINKS
 

--- a/scrollimate.js
+++ b/scrollimate.js
@@ -17,6 +17,7 @@ var scrollimate = (function( window, $ ){
     saWinHi: '',
     mobileEnabled: false,
     isMObile: false,
+    indexable: true,
   };
 
   /* * checks and sets variable that enables parallax even on mobile in init function * */
@@ -243,10 +244,21 @@ var scrollimate = (function( window, $ ){
     $($tabscrollAnchors[0]).parent().addClass("tabscroll_activeNavi");
 
     for ($i = 0; $i < $tabscrollAnchors.length; $i++){
-      var $eachAnchor = $($tabscrollAnchors[$i]).attr("href");
-      $($tabscrollAnchors[$i]).parent().attr("data-tabscrollnavi", $eachAnchor.substring(1)); 
-      $($eachAnchor).attr("data-tabscroll", $eachAnchor.substring(1));
-    }    
+      var $curEl = $($tabscrollAnchors[$i]),
+          eachAnchor = $curEl.attr("href");
+      $curEl.parent().attr("data-tabscrollnavi", eachAnchor.substring(1)); 
+      $(eachAnchor).attr("data-tabscroll", eachAnchor.substring(1));
+
+      // removes link if in non-indexable version (to not interfere with app status keeping)
+      if(!_global.indexable){
+        $curEl.removeAttr("href").css('cursor', 'pointer');
+        $curEl.on('click', function(){
+          var tab_target = $(this).parent().attr("data-tabscrollnavi");
+          console.log( tab_target );
+          _saTabsHashChangeFunct(tab_target);
+        });
+      }
+    }
     
     $("[data-tabscroll]").removeAttr('id');
     $("[data-tabscroll]:first-of-type").siblings("[data-tabscroll]").hide();   
@@ -258,6 +270,9 @@ var scrollimate = (function( window, $ ){
    *    Called both initially in saTabs and also on each Hash (URL fragment) change, monitured
    *    by the saTabs Method.
    *
+   *    If this function is called with an input parameter, use that as location. This means it was
+   *    called as the non-indexed version through a click event. If not, grab location from the href
+   *
    *    Writing the URL that raised the event into a string, stripping off everything before the hash
    *    In order to parse the users navigational input.
    *
@@ -268,21 +283,30 @@ var scrollimate = (function( window, $ ){
    *    Finally, also checks for the 'fade' and 'slide' transition types, and executes different 
    *    funcionality, which I would like to break out into different functions eventually.
    */
-  var _saTabsHashChangeFunct = function() {
-    /* checks the current location, matches it to the href-containing link, and adds correct class to parent */
-    var __activeClassHelperFunction = function($inputLoc){
-      for (i=0; i<$tabscrollAnchors.length; i++){
-        if( $($tabscrollAnchors[i]).attr('href') === "#"+$inputLoc ){
+  var _saTabsHashChangeFunct = function( masterinput ) {
+    /* checks the current location, matches it to the element containing the link, and adds correct class */
+    var __activeClassHelperFunction = function(inputLoc){
+      var $naviEls = $('[data-tabscrollnavi]');
+      for (i=0; i<$naviEls.length; i++){
+        var $curEl = $($naviEls[i]);
+        if( $curEl.data('tabscrollnavi') === inputLoc ){
           $('.tabscroll_activeNavi').removeClass('tabscroll_activeNavi');
-          $($tabscrollAnchors[i]).parent().addClass('tabscroll_activeNavi');
+          $curEl.addClass('tabscroll_activeNavi');
         }
       }
     };
 
-    var $location = String(document.location);    
-    $location = $location = $location.split("#")[1];
+    var location;
 
-    if ($location === undefined || $location === 'all' ){
+    if (typeof masterinput !== 'undefined') {
+      location = masterinput;
+    }
+    else{
+      location = String(document.location);    
+      location = location = location.split("#")[1]; // wtf is this ...
+    }
+
+    if (location === undefined || location === 'all' ){
         $("[data-tabscroll]:first-of-type").show();   
         $("[data-tabscroll]:first-of-type").addClass('activeTab');   
     }
@@ -290,26 +314,27 @@ var scrollimate = (function( window, $ ){
       $("[data-tabscroll]").hide().removeClass('activeTab');   
 
       if ( $transition_type === 'fade') {
-        $("[data-tabscroll='"+$location+"']").fadeIn().addClass('activeTab');   
-        __activeClassHelperFunction($location);
+        $("[data-tabscroll='"+location+"']").fadeIn().addClass('activeTab');   
+        __activeClassHelperFunction(location);
 
       } 
       else if ( $transition_type === 'slide') {
-        $("[data-tabscroll='"+$location+"']").slideDown().addClass('activeTab');   
-        __activeClassHelperFunction($location);
+        $("[data-tabscroll='"+location+"']").slideDown().addClass('activeTab');   
+        __activeClassHelperFunction(location);
       }
       else{
-        $("[data-tabscroll='"+$location+"']").show().addClass('activeTab');   
-        __activeClassHelperFunction($location);
+        $("[data-tabscroll='"+location+"']").show().addClass('activeTab');   
+        __activeClassHelperFunction(location);
       }
     }             
   };
 
-  /**
+ /**
    *
    * 1: saTabs: 
    *    Runs the _saTabsSetUpPage function, the initial instance of the _saTabsHashChangeFunct,
    *    then also monitors the hash change to run the _saTabsHashChangeFunct as needed.
+   *    Only Monitors hash change if the indexable setting is set to true
    *
    *    Hash changed is implemented as follows:
    *    Stores the previous hash, then listens if it has changed every frew millisectons
@@ -319,14 +344,16 @@ var scrollimate = (function( window, $ ){
    */
   var saTabs = function () {
     _saTabsSetUpPage();
-    
-    var prevHash = window.location.hash;
-    window.setInterval(function () {
-      if (window.location.hash !== prevHash) {
-        prevHash = window.location.hash;
-        _saTabsHashChangeFunct();
-      }
-    }, 100);
+
+    if(_global.indexable){
+      var prevHash = window.location.hash;
+      window.setInterval(function () {
+        if (window.location.hash !== prevHash) {
+          prevHash = window.location.hash;
+          _saTabsHashChangeFunct();
+        }
+      }, 100);
+    }
     
     $(window).load(function(){
        _saTabsHashChangeFunct();
@@ -334,6 +361,13 @@ var scrollimate = (function( window, $ ){
 
     console.log('saTabs initiated');
   }; 
+
+  /**
+  * Public Helper Method that sets the SA TABS status to non-indexable 
+  */
+  var nonIDTabs = function(){
+    _global.indexable = false;
+  };
  
 
   /**
@@ -481,6 +515,7 @@ var scrollimate = (function( window, $ ){
     saScrollClass: saScrollClass,
     saAccordion: saAccordion,
     init: init,
+    nonIDTabs: nonIDTabs,
     enableMobile: enableMobile,
   };
 })(window, jQuery);


### PR DESCRIPTION
This Version adds functionality that allows Tabscroll to be used in a “non-indexed version” that does not keep track of its state via the URL but instead uses click events to change tabs. Useful if your page already tracks another application state via the URL.